### PR TITLE
Discovered a further issue with the job delete synchronization code. 

### DIFF
--- a/www/submit_job_to_qiime.psp
+++ b/www/submit_job_to_qiime.psp
@@ -20,20 +20,21 @@ study_id = int(sess['study_id'])
 user_id = int(sess['web_app_user_id'])
 mapping_file_dir = sess['mapping_file_dir']
 study_dir = sess['study_dir']
-
 process_only = str(form['process_only'])
 submit_to_test_db = str(form['submit_to_test_db'])
-# Submit the jobs
+cleanup_in_progress = join(base_dir, '_cleanup_in_progress')
+cleanup_complete = join(base_dir, '_cleanup_complete')
+
 try:
-    # First, remove the synchronization_file if it exists. This file prevents multiple nodes
-    # from attempting to remove database and filesystem data at the same time. However if something
-    # goes wrong the file could still exist. This code ensures that we start from a clean slate.
-    synchronization_file = join(study_dir, 'synchronization_file')
-    if exists(synchronization_file):
-        remove(synchronization_file)
+    # Clean up the synchronization files before submitting 
+    if exists(cleanup_in_progress):
+        remove(cleanup_in_progress)
+    if exists(cleanup_complete):
+        remove(cleanup_complete)
 
     # Submit the jobs
     submitJobsToQiime(study_id, user_id, mapping_file_dir, process_only, submit_to_test_db)
+    
     # Redirect to the home page for this study
     psp.redirect('fusebox.psp?page=select_study_task.psp')
 except Exception, e:


### PR DESCRIPTION
This hopefully contains a final fix for this issue. The logic is as follows:

Since these are completely separate processes on different machines, there aren't too many ways for each process to communicate with each other. The original fix utilized a synchronization file to tell the other proceses that one process was already performing the delete operation. The other processes that saw this blocked until this file was removed. 

Unfortunately this didn't quite cover it when the delete operations were extremely fast - it was still possible for one job to completely finish it's delete, cleanup the sync file, then have another job get started after the fact and perform the delete all over again.

The new solution is this: A cleanup_in_progress file is created by the first process that performs the cleanup operation. This process then performs the deletion of database data and file system data. When it completes, it writes yet another file called cleanup_complete. The other processes check first to see if the cleanup_in_progress file exists. If so, it will wait until the cleanup_complete file exists, at which time they simply skip the delete operations and proceed with processing.

Hopefully this logic guarantees that only one process will ever enter that code section and the other processes must wait until that proces has finished deleting.
