### PR TITLE
Added support in the jumploader for gzipped SFFs

### DIFF
--- a/www/upload_sff.psp
+++ b/www/upload_sff.psp
@@ -22,7 +22,7 @@ data_access = data_access_factory(ServerConfig.data_access_type)
         <li><b>SFF:</b> You should zip using "zip" for each SFF file individually prior to uploading.</li>
         <li><b>FASTQ:</b> For each Illumina lane, there should be a single barcode file that associates to a single amplicon read file. Each of these files should be gzipped using "gzip" prior to uploading. We do not currently support assembly, so only one amplicon read file is permitted for each barcode file.</li>
         <li><b>FASTA:</b> We are expecting a FASTA-formatted file that is formatted similar to the file produced from split-libraries.py. For more information on the format, please refer to <a href="http://qiime.org/documentation/file_formats.html#demultiplexed-sequences">here</a>. Make sure the extension for each FASTA file is either ".fna", ".fasta" or "fa", then zip using "zip" for each file individually prior to uploading.</li>
-        <li><i>Allowable file extensions:</i> .sff.zip, .fastq.gz, .fastq.gz.zip, .fa.zip, .fna.zip, or .fasta.zip</li>
+        <li><i>Allowable file extensions:</i> .sff.zip, .sff.gz, .fastq.gz, .fastq.gz.zip, .fa.zip, .fna.zip, or .fasta.zip</li>
     </ul>
 </p>
 <script type="text/javascript">
@@ -170,7 +170,7 @@ function setCompleteBox()
     <param name="vc_uploadViewStopUploadButtonText" value="Stop upload"/>
     <param name="vc_uploadViewStopUploadButtonImageUrl" value="/img/media_stop_red.png"/>
     <param name="ac_fireAppletInitialized" value="true"/> 
-    <param name="uc_fileNamePattern" value='^.+\.((zip|fastq.gz))' />
+    <param name="uc_fileNamePattern" value='^.+\.((zip|fastq.gz|sff.gz))' />
     <param name="ac_fireUploaderFileStatusChanged" value="true"/>
     <param name="uc_uploadUrl" value="upload_sff_submit.psp">
     <param name="gc_loggingLevel" value="DEBUG"/>

--- a/www/upload_sff_submit.psp
+++ b/www/upload_sff_submit.psp
@@ -141,7 +141,8 @@ if form.has_key('file') and form['file'].filename:
                         except Exception, e:
                             req.write("Error: there was a problem parsing the FNA file. Requested path: %s. The error was: %s" % (dir_path, str(e)))
                         
-        elif zip_file_name.endswith(".fastq.gz") and \
+        elif (zip_file_name.endswith(".fastq.gz") \
+             or zip_file_name.endswith(".sff.gz")) and \
                                         not zip_file_name.startswith('.'):
             # Unzip the file using the system's unzip command. Python has a 
             # bug which prevents
@@ -154,12 +155,18 @@ if form.has_key('file') and form['file'].filename:
             sequence_read_f = gzip_open(zip_file_name)
     
             contains_valid_file = True
+
+            if zip_file_name.endswith(".fastq.gz"):
+                file_type = 'FASTQ'
+            elif zip_file_name.endswith(".sff.gz"):
+                file_type = 'SFF'
+
             try: 
                 MinimalFastqParser(sequence_read_f)
                 data_access.addSeqFile(form['study_id'], zip_file_name, 
-                                                                'FASTQ')
+                                                                file_type)
             except Exception, e:
-                req.write("Error: there was a problem parsing the FASTQ file. Requested path: %s. The error was: %s" % (dir_path, str(e)))
+                req.write("Error: there was a problem parsing the sequence file. Requested path: %s. The error was: %s" % (dir_path, str(e)))
         
         #if the zip does not have any sff,fastq, or fasta files, raise an error
         if contains_valid_file==False:


### PR DESCRIPTION
upload_sff.psp: Modified applet initialization so that .sff.gz
                files are listed
upload_sff_submit.psp: Modified code to expect .sff.gz files

The changes work on webdev.
