### PR TITLE
Add working mechanism to logout from the site

### DIFF
--- a/www/americangut/logout.psp
+++ b/www/americangut/logout.psp
@@ -1,0 +1,22 @@
+<%
+__author__ = "Yoshiki Vazquez-Baeza"
+__copyright__ = "Copyright 2009-2013, QIIME Web Analysis"
+__credits__ = ["Meg Pirrung", "Adam Robbins-Pianka", "Yoshiki Vazquez-Baeza",
+    "Doug Wendel"]
+__license__ = "GPL"
+__version__ = "1.0.0.dev"
+__maintainer__ = ["Yoshiki Vazquez-Baeza"]
+__email__ = "yoshiki89@gmail.com"
+__status__ = "Development"
+
+
+sess = Session.Session(req)
+
+# header.psp ensures these exist, else it's going to send you to index.psp
+del sess['user_data']
+del sess['username']
+del sess['supplied_kit_id']
+sess.save()
+
+psp.redirect('index.psp')
+%>

--- a/www/americangut/logout.psp
+++ b/www/americangut/logout.psp
@@ -13,9 +13,12 @@ __status__ = "Development"
 sess = Session.Session(req)
 
 # header.psp ensures these exist, else it's going to send you to index.psp
-del sess['user_data']
-del sess['username']
-del sess['supplied_kit_id']
+for key in ['user_data', 'username', 'supplied_kit_id']:
+    try:
+        del sess[key]
+    except:
+        continue
+
 sess.save()
 
 psp.redirect('index.psp')

--- a/www/americangut/menu.psp
+++ b/www/americangut/menu.psp
@@ -65,6 +65,6 @@ for p in participants:
         <li><a href=""><img class="icon" src="/qiime/img/purchase_icon.png">Join the project!</a></li>
         <li><a href="http://americangut.org"><img class="icon" src="/qiime/img/what_icon.png">What is American Gut</a></li>
         <li><a href="fusebox.psp?page=help_request.psp"><img class="icon" src="/qiime/img/mail_icon.png">Contact us</a></li>
-        <li><a href="index.psp"><img class="icon" src="/qiime/img/logout_icon.png">Log out</a></li>
+        <li><a href="logout.psp"><img class="icon" src="/qiime/img/logout_icon.png">Log out</a></li>
 	</ul>
 </div>


### PR DESCRIPTION
logout.psp takes care of removing the session variables that make a
session active, hence menu.psp now sends you here instead of sending you
to index.psp.

This fixes #183

:shipit: 
