### PR TITLE
Fixes #202, Logout from index

### DIFF
--- a/www/americangut/index.psp
+++ b/www/americangut/index.psp
@@ -39,8 +39,8 @@ ag_data_access = data_access_factory(ServerConfig.data_access_type,
 # Session variables
 sess = Session.Session(req)
 
-#if 'username' in sess:
-    #psp.redirect('logout.psp')
+if 'username' in sess:
+    psp.redirect('logout.psp')
 
 sess['portal_type'] = portal_type
 sess['document_root'] = req.document_root() + '/americangut/'

--- a/www/americangut/index.psp
+++ b/www/americangut/index.psp
@@ -38,6 +38,10 @@ ag_data_access = data_access_factory(ServerConfig.data_access_type,
 
 # Session variables
 sess = Session.Session(req)
+
+#if 'username' in sess:
+    #psp.redirect('logout.psp')
+
 sess['portal_type'] = portal_type
 sess['document_root'] = req.document_root() + '/americangut/'
 sess['resources'] = {}


### PR DESCRIPTION
If the user is already logged in and finds himself/herself on index.psp, this will automatically log him/her out.  The user should never get to a page that asks him/her to login when already logged in.
