### PR TITLE
Format consent

### DIFF
--- a/www/americangut/index.psp
+++ b/www/americangut/index.psp
@@ -19,7 +19,7 @@ from qiime.parse import parse_mapping_file
 
 
 # Set variables
-zoom_level = 5
+zoom_level = 4
 
 # center of US
 center_lat = 39.83389

--- a/www/americangut/new_participant.psp
+++ b/www/americangut/new_participant.psp
@@ -121,7 +121,7 @@ To withdraw from the study send email to the <a href="mailto:info@americangut.or
 <div class="lefta">
         <div class="" id="consent">
         <form method="post" id="consent_info" name="consent_info" action="fusebox.psp">
-            <input tabindex="1" type="checkbox" name="consent" id="consent"> I have read (or someone has read to me) this form. I am aware that I am being 
+            <input tabindex="1" value="yes" type="checkbox" name="consent" id="consent"> I have read (or someone has read to me) this form. I am aware that I am being 
             asked to provide personally identifying information so that I can be considered for inclusion into the study. I voluntarily agree 
             to provide this information. I am not giving up any legal rights by signing this form. I will be sent a copy of this form by e-mail.
         </div>

--- a/www/americangut/new_participant.psp
+++ b/www/americangut/new_participant.psp
@@ -121,7 +121,7 @@ To withdraw from the study send email to the <a href="mailto:info@americangut.or
 <div class="lefta">
         <div class="" id="consent">
         <form method="post" id="consent_info" name="consent_info" action="fusebox.psp">
-            <input tabindex="1" value="yes" type="checkbox" name="consent" id="consent"> I have read (or someone has read to me) this form. I am aware that I am being 
+            <input tabindex="1" value="Yes" type="checkbox" name="consent" id="consent"> I have read (or someone has read to me) this form. I am aware that I am being 
             asked to provide personally identifying information so that I can be considered for inclusion into the study. I voluntarily agree 
             to provide this information. I am not giving up any legal rights by signing this form. I will be sent a copy of this form by e-mail.
         </div>

--- a/www/americangut/submit_human_survey.psp
+++ b/www/americangut/submit_human_survey.psp
@@ -175,7 +175,7 @@ Participant Email: %s
 Participant Guardian 1: %s
 Participant Guardian 2: %s
 --------------------------------------------------------------------------------
-%s
+%s, I have read (or someone has read to me) this form. I am aware that I am being asked to provide personally identifying information so that I can be considered for inclusion into the study. I voluntarily agree to provide this information. I am not giving up any legal rights by signing this form. I will be sent a copy of this form by e-mail.
 --------------------------------------------------------------------------------
 %s
 --------------------------------------------------------------------------------

--- a/www/americangut/submit_human_survey.psp
+++ b/www/americangut/submit_human_survey.psp
@@ -117,6 +117,9 @@ message = ""
 # Insert the new row
 participant_email = form['participant_email']
 participant_name = form['participant_name']
+participant_guardian_1 = form.get('parent_1_name', 'NA')
+participant_guardian_2 = form.get('parent_2_name', 'NA')
+consent_text = form.get('consent', 'NA')
 ag_login_id = sess['user_data']['web_app_user_id']
 
 # Clear any old data for this participant
@@ -167,19 +170,25 @@ SUBJECT = "American Gut Consent Form"
 MESSAGE = """
 --------------------------------------------------------------------------------
 Consent Form:
-
-%s
-
+Participant Name: %s
+Participant Email: %s
+Participant Guardian 1: %s
+Participant Guardian 2: %s
 --------------------------------------------------------------------------------
-""" % AG_CONSENT_TEXT
+%s
+--------------------------------------------------------------------------------
+%s
+--------------------------------------------------------------------------------
+""" % (participant_name, participant_email, participant_guardian_1,
+	participant_guardian_2, consent_text, AG_CONSENT_TEXT)
 
 try:
-    send_email(MESSAGE, SUBJECT, participant_email)
-    message+="Consent form successfully sent to: %s.<br/>" % participant_email
+	send_email(MESSAGE, SUBJECT, participant_email)
+	message+="Consent form successfully sent to: %s.<br/>" % participant_email
 except:
-    message+=("There was a problem sending you the consent form. Please contact"
-        " us directly at <a href=&quot;mailto:info@americangut.org&quot;>"
-        "info@americangut.org</a>.<br/>")
+	message+=("There was a problem sending you the consent form. Please contact"
+		" us directly at <a href=&quot;mailto:info@americangut.org&quot;>"
+		"info@americangut.org</a>.<br/>")
 
 # default message to display upon redirect to portal
 message+=("%s successfully added as a participant! " % participant_name)


### PR DESCRIPTION
Improves the formatting for the e-mail that get's sent to the user when they accept the consent.

:shipit: 
