### PR TITLE
Fixing issue #287

### DIFF
--- a/www/americangut/index.psp
+++ b/www/americangut/index.psp
@@ -260,7 +260,7 @@ if form.has_key('username'):
         url = 'fusebox.psp?page=portal.psp'
         req.write('<script language=\"javascript\">window.location="{0}";</script>'.format(url))
     else:
-        req.write("<p style='color:#FF0000;'>Invalid username/password.</p>")
+        req.write("<p style='color:#FF0000;'>Invalid Kit ID/password.</p>")
 
 # end
 


### PR DESCRIPTION
Changing login error text to "Invalid Kit ID/password"
