### PR TITLE
Now requests only last 2 letters of Kit IDs

### DIFF
--- a/www/americangut/help_request.psp
+++ b/www/americangut/help_request.psp
@@ -17,10 +17,11 @@ from utils.psp_utils import format_submit_form_to_fusebox_string
 
 form_dict = dict(form)
 email_address = form_dict.get('email_address', None)
+supplied_kit_id = sess['supplied_kit_id']
 
 if email_address:
-    SUBJECT = """AGHELP: %s %s""" % (form_dict['first_name'],
-        form_dict['last_name'])
+    SUBJECT = """AGHELP: %s %s %s""" % (form_dict['first_name'],
+        form_dict['last_name'], supplied_kit_id[-2:])
 
     MESSAGE = """Contact: %s %s
     Reply to: %s

--- a/www/americangut/index.psp
+++ b/www/americangut/index.psp
@@ -278,7 +278,7 @@ if form.has_key('username'):
                             	<tr><td>Kit ID</td><td><input type="text" id="username" name="username"></td></tr>
                             	<tr><td>Password</td><td><input type="password" id="password" name="password"></td></tr>
                             	<tr><td colspan="2"><input type="submit" value="Log In"></tr>
-                                <tr><td colspan="2"><a href="mailto:americangut@gmail.com?subject=AGLOGINHELP&body=Please%20add%20your%20KitID%20and%20any%20other%20relevant%20information" class="small_link">I'm having trouble logging in...</a></td></tr>
+                                <tr><td colspan="2"><a href="mailto:americangut@gmail.com?subject=AGLOGINHELP&body=Please%20include%20the%20last%20two%20digits%20of%20your%20Kit%20ID" class="small_link">I'm having trouble logging in...</a></td></tr>
                             </table>
                         </form>
                     </td>


### PR DESCRIPTION
Emails sent through the UI now automatically append the last two digits of the Kit ID to the subject line.  the mailto link on index.psp has been changed so that it now asks the user to include only the last twi digits of their kit ID.
