### PR TITLE
Change study summary display -- fix #340

### DIFF
--- a/www/study_summary/index.psp
+++ b/www/study_summary/index.psp
@@ -73,14 +73,14 @@ This form contains the input box for the list of studies.
         <td>
         <form onsubmit="return false;">
 
-            <select id="box1View" multiple="multiple" style="height:200px;">
+            <select id="box1View" size=2 style="height:200px;"
+            onchange="showStudySummary(this.id)">
                 <!-- Using psp, generate a list of studies -->
 <%
 #write out the list of public studies
 for i in public_studies:
-    req.write("<option id='"+str(i[0])+'_'+str(i[1])+" value='"+str(i[1])+\
-        "' onclick=\"showResult(\'metadata_left_col\',this.id,this.value)\">"+\
-        str(i[1])+"</option>\n")
+    req.write("<option id='"+str(i[0])+'_'+str(i[1])+"' value='"+str(i[1])+\
+        "'> "+ str(i[1])+"</option>\n")
 #
 %>
             </select>

--- a/www/study_summary/study_summary_selection.js
+++ b/www/study_summary/study_summary_selection.js
@@ -21,9 +21,11 @@ var xmlhttp
         3) the input box id
         4) the txt box below input id
 */
-function showResult(input_textbox,column_id,column_value)
+function showStudySummary(select_box_id)
 {
-    select_box_id=document.getElementById(column_id).parentNode.id
+    select_box=document.getElementById(select_box_id)
+    selected_item_id = select_box.options[select_box.selectedIndex].id
+    study_name=select_box.options[select_box.selectedIndex].value
 
     xmlhttp=GetXmlHttpObject()
     
@@ -36,11 +38,7 @@ function showResult(input_textbox,column_id,column_value)
     // Reset the table while loading
     document.getElementById('field_ref_table').innerHTML = "Loading...";
     
-    col_split_1=column_id.split('_');
-    study_id=col_split_1[0];
-
-    study_name=column_value
-
+    study_id=selected_item_id.split('_')[0]
 
     //generate a url string where we pass our variables
     var url="study_summary/study_reference_lookup.psp";


### PR DESCRIPTION
This select box will allow you now to show the study summary when
navigating using the arrow keys as well as clicking on the study.

The number of studies you can select has now been limited to one
previously it was allowing you to select multiple studies and making
the interaction confusing.

The callback javascript function was changed to only take one argument
the id of the select box so it retrieves the selected item and displays
the study summary data.
