### PR TITLE
Adjusting css for sample_overview

### DIFF
--- a/www/americangut/sample_overview.psp
+++ b/www/americangut/sample_overview.psp
@@ -27,7 +27,7 @@ remove_sample_item = \
 <h2>Overview for <%=barcode%></h2>
 <div class="overview_wrapper">
     <div class="overview">
-            <table class="list" id="survey" width="100%">
+            <table class="list" id="survey">
                 <tr>
                     <td style="width: 150px;">Sample Site</td>
                     <td><%=site_sampled%></td>
@@ -42,7 +42,11 @@ remove_sample_item = \
                 </tr>
                 <tr>
                     <td>Notes</td>
-                    <td><%=notes%></td>
+                    <td>
+                        <div class="notescroll">
+                            <%=notes%>
+                        </div>
+                    </td>
                 </tr>
                 <tr>
                     <td colspan="2"><%=remove_sample_item%></td>

--- a/www/americangut/style/americangut.css
+++ b/www/americangut/style/americangut.css
@@ -39,11 +39,11 @@ div.overview_wrapper {
     height: 100%;
     margin: 0;
     padding: 0;
-    text-align: left;
+/*    text-align: left;*/
 }
 
 div.overview {
-	width: 90%;
+	width: 50%;
     display: block;
     margin-left: auto;
     margin-right: auto;
@@ -168,6 +168,11 @@ ul.faq li a {
 	text-decoration: none;
 }
 
+ul.shipping {
+/*	list-style-type: none;*/
+	font-size: 12pt;
+}
+
 ul.next_steps {
 	padding-right: 1em;
 }
@@ -272,6 +277,15 @@ div.scroll {
     height: 450px;
     overflow: scroll;
     font-size: 10pt;
+}
+
+div.notescroll {
+    width: 200px;
+    height: 100px;
+    overflow: scroll;
+    font-size: 10pt;
+	background-color: #fff;
+	text-align: left;
 }
 
 div.left {


### PR DESCRIPTION
Put the notes field in a scroll box so it doesn't take up lots of space and the overview is better centered in the page
