### PR TITLE
Change submission from fusebox.psp to index.psp

### DIFF
--- a/www/emp/index.psp
+++ b/www/emp/index.psp
@@ -195,13 +195,19 @@ if form.has_key('username'):
         sess['web_app_user_id'] = user_data['web_app_user_id']
         sess['study_name'] = ''
         sess['frame_target'] = '_parent'
+        sess['portal_type'] = 'emp'
 
         sess.set_timeout(604800)
         sess.save()
 
-        req.write('''<form action="http://www.microbio.me/qiime/fusebox.psp" method="post" name="login_form" id="login_form">
+        req.write('''<form action="http://www.microbio.me/qiime/index.psp" method="post" name="login_form" id="login_form">
         <input type="hidden" name="page" value="./select_study.psp">
-        </form>''')
+        <input type="hidden" name="portal_type" value="emp">
+        <input type="hidden" name="username" value="%s">
+        <input type="hidden" name="password" value="%s">
+        <input type="hidden" name="is_admin" value="%s">
+        </form>''' % (form["username"], form["password"],
+            user_data["is_admin"]))
 
         req.write('<script language=\"javascript\">document.login_form.submit();</script>')
     else:


### PR DESCRIPTION
Form was submitting to fusebox.psp previously, now it submits to index.psp.  Also, added extra form values (username, password, portal_type, is_admin) to make it as similar as possible to the previous code that used a GET request.
