### PR TITLE
Fix PGP logins

### DIFF
--- a/www/americangut/index.psp
+++ b/www/americangut/index.psp
@@ -270,7 +270,7 @@ if form.has_key('username'):
     <input type="hidden" name="password" id="password" value="<%=password%>">
 </form>
 
-<script>document.register_user.submit(); return false;</script>
+<script>document.register_user.submit();</script>
 
 <%
         # End is_handout indent

--- a/www/americangut/index.psp
+++ b/www/americangut/index.psp
@@ -270,7 +270,7 @@ if form.has_key('username'):
     <input type="hidden" name="password" id="password" value="<%=password%>">
 </form>
 
-<script>document.register_user.submit();</script>
+<script>document.register_user.submit(); return false;</script>
 
 <%
         # End is_handout indent


### PR DESCRIPTION
"return false;" in index.psp was causing syntax error
