### PR TITLE
Add format template to date and hour in add sample

### DIFF
--- a/www/americangut/add_sample_animal.psp
+++ b/www/americangut/add_sample_animal.psp
@@ -44,7 +44,7 @@ for barcode in barcodes:
                 </tr>
                 <tr>
                     <td>Date</td>
-                    <td><input tabindex="3" type="text" name="sample_date" id="sample_date" class="small_text" /></td>
+                    <td><input tabindex="3" type="text" name="sample_date" id="sample_date" class="small_text" /> mm/dd/yyyy</td>
                     <script>
                       $(function() {
                         $( "#sample_date" ).datepicker({
@@ -61,8 +61,7 @@ for barcode in barcodes:
                 <tr>
                     <td>Time</td>
                     <td>
-                        <input tabindex="4" type="text" id="sample_time" name="sample_time" class="small_text" />
-                    </td>
+                        <input tabindex="4" type="text" id="sample_time" name="sample_time" class="small_text" /> hh:mm AM/PM</td>
                     <script>
                       $(function() {
                         $( "#sample_time" ).timepicker({

--- a/www/americangut/add_sample_animal.psp
+++ b/www/americangut/add_sample_animal.psp
@@ -44,7 +44,7 @@ for barcode in barcodes:
                 </tr>
                 <tr>
                     <td>Date</td>
-                    <td><input tabindex="3" type="text" name="sample_date" id="sample_date" class="small_text" /> mm/dd/yyyy</td>
+                    <td><input tabindex="3" type="text" name="sample_date" id="sample_date" class="small_text" /> mm/dd/yyyy (Example: 05/07/2013)</td>
                     <script>
                       $(function() {
                         $( "#sample_date" ).datepicker({
@@ -61,7 +61,7 @@ for barcode in barcodes:
                 <tr>
                     <td>Time</td>
                     <td>
-                        <input tabindex="4" type="text" id="sample_time" name="sample_time" class="small_text" /> hh:mm AM/PM</td>
+                        <input tabindex="4" type="text" id="sample_time" name="sample_time" class="small_text" /> hh:mm AM/PM (Example: 04:35 PM)</td>
                     <script>
                       $(function() {
                         $( "#sample_time" ).timepicker({

--- a/www/americangut/add_sample_general.psp
+++ b/www/americangut/add_sample_general.psp
@@ -49,7 +49,7 @@ for barcode in barcodes:
                 </tr>
                 <tr>
                     <td>Date</td>
-                    <td><input tabindex="3" type="text" name="sample_date" id="sample_date" class="small_text" /> mm/dd/yyyy</td>
+                    <td><input tabindex="3" type="text" name="sample_date" id="sample_date" class="small_text" /> mm/dd/yyyy (Example: 05/07/2013)</td>
                     <script>
                       $(function() {
                         $( "#sample_date" ).datepicker({
@@ -66,7 +66,7 @@ for barcode in barcodes:
                 <tr>
                     <td>Time</td>
                     <td>
-                        <input tabindex="4" type="text" id="sample_time" name="sample_time" class="small_text" /> hh:mm AM/PM</td>
+                        <input tabindex="4" type="text" id="sample_time" name="sample_time" class="small_text" /> hh:mm AM/PM (Example: 04:35 PM)</td>
                     <script>
                       $(function() {
                         $( "#sample_time" ).timepicker({

--- a/www/americangut/add_sample_general.psp
+++ b/www/americangut/add_sample_general.psp
@@ -49,7 +49,7 @@ for barcode in barcodes:
                 </tr>
                 <tr>
                     <td>Date</td>
-                    <td><input tabindex="3" type="text" name="sample_date" id="sample_date" class="small_text" /></td>
+                    <td><input tabindex="3" type="text" name="sample_date" id="sample_date" class="small_text" /> mm/dd/yyyy</td>
                     <script>
                       $(function() {
                         $( "#sample_date" ).datepicker({
@@ -66,8 +66,7 @@ for barcode in barcodes:
                 <tr>
                     <td>Time</td>
                     <td>
-                        <input tabindex="4" type="text" id="sample_time" name="sample_time" class="small_text" />
-                    </td>
+                        <input tabindex="4" type="text" id="sample_time" name="sample_time" class="small_text" /> hh:mm AM/PM</td>
                     <script>
                       $(function() {
                         $( "#sample_time" ).timepicker({

--- a/www/americangut/add_sample_human.psp
+++ b/www/americangut/add_sample_human.psp
@@ -47,7 +47,7 @@ for barcode in barcodes:
                 </tr>
                 <tr>
                     <td>Date</td>
-                    <td><input tabindex="3" type="text" name="sample_date" id="sample_date" class="small_text" /> mm/dd/yyyy</td>
+                    <td><input tabindex="3" type="text" name="sample_date" id="sample_date" class="small_text" /> mm/dd/yyyy (Example: 05/07/2013)</td>
                     <script>
                       $(function() {
                         $( "#sample_date" ).datepicker({
@@ -64,7 +64,7 @@ for barcode in barcodes:
                 <tr>
                     <td>Time</td>
                     <td>
-                        <input tabindex="4" type="text" id="sample_time" name="sample_time" class="small_text" /> hh:mm AM/PM</td>
+                        <input tabindex="4" type="text" id="sample_time" name="sample_time" class="small_text" /> hh:mm AM/PM (Example: 04:35 PM)</td>
                     <script>
                       $(function() {
                         $( "#sample_time" ).timepicker({

--- a/www/americangut/add_sample_human.psp
+++ b/www/americangut/add_sample_human.psp
@@ -47,7 +47,7 @@ for barcode in barcodes:
                 </tr>
                 <tr>
                     <td>Date</td>
-                    <td><input tabindex="3" type="text" name="sample_date" id="sample_date" class="small_text" /></td>
+                    <td><input tabindex="3" type="text" name="sample_date" id="sample_date" class="small_text" /> mm/dd/yyyy</td>
                     <script>
                       $(function() {
                         $( "#sample_date" ).datepicker({
@@ -64,8 +64,7 @@ for barcode in barcodes:
                 <tr>
                     <td>Time</td>
                     <td>
-                        <input tabindex="4" type="text" id="sample_time" name="sample_time" class="small_text" />
-                    </td>
+                        <input tabindex="4" type="text" id="sample_time" name="sample_time" class="small_text" /> hh:mm AM/PM</td>
                     <script>
                       $(function() {
                         $( "#sample_time" ).timepicker({


### PR DESCRIPTION
Add `mm/dd/yyyy` to the side of each of the date text entry boxes in the
three `add_sample_*.psp` menus, as well as `hh:mm AM/PM` for the collection
hour.

Note that I selected `hh:mm AM/PM` instead of `hh:mm tt` because I figured it wouldn't be clear for some people.
