### PR TITLE
Added sample sites for office succession

### DIFF
--- a/www/americangut/add_sample_general.psp
+++ b/www/americangut/add_sample_general.psp
@@ -44,6 +44,7 @@ for barcode in barcodes:
                             <option>Outdoor Surface</option>
                             <option>Plant habitat</option>
                             <option>Soil</option>
+                            <option>Sole of shoe</option>
                         </select>
                     </td>
                 </tr>

--- a/www/americangut/add_sample_human.psp
+++ b/www/americangut/add_sample_human.psp
@@ -42,6 +42,8 @@ for barcode in barcodes:
                             <option>Right hand</option>
                             <option>Left hand</option>
                             <option>Forehead</option>
+                            <option>Nares</option>
+                            <option>Hair</option>
                         </select>
                     </td>
                 </tr>


### PR DESCRIPTION
Added sample types for the office succession project

@gregcaporaso I think this covers what is necessary and was much lighter changes than anticipated. Once live, should just be on the forms when adding samples.

@douginator2000 I couldn't drop this in the dev environment due to the current qb downtime, but the changes are very minimal.
