### PR TITLE
Modify AGLOGINHELP email

### DIFF
--- a/www/americangut/index.psp
+++ b/www/americangut/index.psp
@@ -327,7 +327,7 @@ if form.has_key('username'):
                             	<tr><td>Kit ID</td><td><input type="text" id="username" name="username"></td></tr>
                             	<tr><td>Password</td><td><input type="password" id="password" name="password"></td></tr>
                             	<tr><td colspan="2"><input type="submit" value="Log In"></tr>
-                                <tr><td colspan="2"><a href="mailto:americangut@gmail.com?subject=AGLOGINHELP&body=Please%20include%20the%20last%20two%20digits%20of%20your%20Kit%20ID" class="small_link">I'm having trouble logging in...</a></td></tr>
+                                <tr><td colspan="2"><a href="mailto:americangut@gmail.com?subject=AGLOGINHELP&body=Please%20describe%20your%20problem%20and%20also%20include%20the%20last%20two%20digits%20of%20your%20Kit%20ID" class="small_link">I'm having trouble logging in...</a></td></tr>
                             </table>
                         </form>
                     </td>


### PR DESCRIPTION
Ask users to describe their problem instead of just asking for the last
2 digits of their kit ID.  Fixes #358.
