### PR TITLE
Fix validate number

### DIFF
--- a/www/americangut/animal_survey.psp
+++ b/www/americangut/animal_survey.psp
@@ -98,7 +98,7 @@ else:
                         </tr>
                         <tr>
                             <td>Age</td>
-                            <td><input tabindex="3" type="text" name="age" id="age" onkeypress='validateNumber(event)' class=""/></td>
+                            <td><input tabindex="3" type="text" name="age" id="age" onkeypress='validateNumber(event, False)' class=""/></td>
                         </tr>
                         <tr>
                             <td>Gender</td>
@@ -201,7 +201,7 @@ else:
                             <td>
                                 <div id="human">
                                     <div id="human_1">
-                                        <input type="text" id="human_1_age" class="small_text" name="human_1_age" value="Age" onkeypress='validateNumber(event)'/> years
+                                        <input type="text" id="human_1_age" class="small_text" name="human_1_age" value="Age" onkeypress='validateNumber(event, False)'/> years
                                         <br />
                                         <select id="human_1_sex" name="human_1_sex">
                                             <option value="">Select an option</option>

--- a/www/americangut/animal_survey.psp
+++ b/www/americangut/animal_survey.psp
@@ -98,7 +98,7 @@ else:
                         </tr>
                         <tr>
                             <td>Age</td>
-                            <td><input tabindex="3" type="text" name="age" id="age" onkeypress='validateNumber(event, False)' class=""/></td>
+                            <td><input tabindex="3" type="text" name="age" id="age" onkeypress='validateNumber(event, false)' class=""/></td>
                         </tr>
                         <tr>
                             <td>Gender</td>
@@ -201,7 +201,7 @@ else:
                             <td>
                                 <div id="human">
                                     <div id="human_1">
-                                        <input type="text" id="human_1_age" class="small_text" name="human_1_age" value="Age" onkeypress='validateNumber(event, False)'/> years
+                                        <input type="text" id="human_1_age" class="small_text" name="human_1_age" value="Age" onkeypress='validateNumber(event, false)'/> years
                                         <br />
                                         <select id="human_1_sex" name="human_1_sex">
                                             <option value="">Select an option</option>

--- a/www/americangut/dietary_questions.psp
+++ b/www/americangut/dietary_questions.psp
@@ -37,19 +37,19 @@ if percentage_from_carbs:
                         <tr>
                             <td>Protein</td>
                             <td>
-                                <input tabindex="1" type="number" max="100" min="0" name="protein_per" id="protein_per" value=<%=quot(form, 'protein_per_default')%> onkeypress='validateNumber(event)' onchange="javascript:updateTotals()" onblur="validatePercentage('protein_per')"/>%
+                                <input tabindex="1" type="number" max="100" min="0" name="protein_per" id="protein_per" value=<%=quot(form, 'protein_per_default')%> onkeypress='validateNumber(event, true)' onchange="javascript:updateTotals()" onblur="validatePercentage('protein_per')"/>%
                             </td>
                         </tr>
                         <tr>
                             <td>Fat</td>
                             <td>
-                                <input tabindex="2" type="number" max="100" min="0" name="fat_per" id="fat_per" value=<%=quot(form, 'fat_per_default')%> onkeypress='validateNumber(event)' onchange="javascript:updateTotals()" onblur="validatePercentage('fat_per')"/>%
+                                <input tabindex="2" type="number" max="100" min="0" name="fat_per" id="fat_per" value=<%=quot(form, 'fat_per_default')%> onkeypress='validateNumber(event, true)' onchange="javascript:updateTotals()" onblur="validatePercentage('fat_per')"/>%
                             </td>
                         </tr>
                         <tr>
                             <td>Carbohydrates</td>
                             <td>
-                                <input tabindex="3" type="number" max="100" min="0" name="carbohydrate_per" id="carbohydrate_per" value=<%=quot(form, 'carbohydrate_per_default')%> onkeypress='validateNumber(event)' onchange="javascript:updateTotals()" onblur="validatePercentage('carbohydrate_per')"/>%
+                                <input tabindex="3" type="number" max="100" min="0" name="carbohydrate_per" id="carbohydrate_per" value=<%=quot(form, 'carbohydrate_per_default')%> onkeypress='validateNumber(event, true)' onchange="javascript:updateTotals()" onblur="validatePercentage('carbohydrate_per')"/>%
                             </td>
                         </tr>
                         <tr>
@@ -62,13 +62,13 @@ if percentage_from_carbs:
                         <tr>
                             <td>Plant</td>
                             <td>
-                                <input tabindex="4" type="number" max="100" min="0" name="plant_per" id="plant_per" value=<%=quot(form, 'plant_per_default')%> onkeypress='validateNumber(event)' onchange="javascript:updateTotals()" onblur="validatePercentage('plant_per')"/>%
+                                <input tabindex="4" type="number" max="100" min="0" name="plant_per" id="plant_per" value=<%=quot(form, 'plant_per_default')%> onkeypress='validateNumber(event, true)' onchange="javascript:updateTotals()" onblur="validatePercentage('plant_per')"/>%
                             </td>
                         </tr>
                         <tr>
                             <td>Animal</td>
                             <td>
-                                <input tabindex="5" type="number" max="100" min="0" name="animal_per" id="animal_per" value=<%=quot(form, 'animal_per_default')%> onkeypress='validateNumber(event)' onchange="javascript:updateTotals()" onblur="validatePercentage('animal_per')"/>%
+                                <input tabindex="5" type="number" max="100" min="0" name="animal_per" id="animal_per" value=<%=quot(form, 'animal_per_default')%> onkeypress='validateNumber(event, true)' onchange="javascript:updateTotals()" onblur="validatePercentage('animal_per')"/>%
                             </td>
                         </tr>
                         <tr>
@@ -81,7 +81,7 @@ if percentage_from_carbs:
                         <tr>
                             <td>Grams of fiber consumed for the 7 day period</td>
                             <td>
-                                <input tabindex="6" type="text" name="fiber_grams" id="fiber_grams" value=<%=quot(form, 'fiber_grams_default')%>/>(g)
+                                <input tabindex="6" type="text" name="fiber_grams" id="fiber_grams" onkeypress='validateNumber(event, false)' value=<%=quot(form, 'fiber_grams_default')%>/>(g)
                             </td>
                         </tr>
                         

--- a/www/americangut/js/american_gut.js
+++ b/www/americangut/js/american_gut.js
@@ -144,7 +144,7 @@ function addDestinationFields(div_name,field1_name,field2_name) {
 		newinput+= '<option value="'+num+'">'+name+'</option>'
 	}
 	newinput+= '</select>'
-	newinput+= '<input type="text" value="Duration" name="'+field2_name+'_'+new_field_number+'" id="'+field2_name+'_'+new_field_number+'" class="smaller_text"/> days <a class="remove_field" href="javascript:removeField(\''+div_name+'_'+new_field_number+'\')" title="Remove this field">x</a></input></div>'
+	newinput+= '<input type="text" value="Duration" name="'+field2_name+'_'+new_field_number+'" id="'+field2_name+'_'+new_field_number+'" class="smaller_text" onkeypress="validateNumber(event)"/> days <a class="remove_field" href="javascript:removeField(\''+div_name+'_'+new_field_number+'\')" title="Remove this field">x</a></input></div>'
 	var newTextBoxDiv = $(document.createElement('div'))
 	     .attr("id", div_name+'_'+new_field_number);
 	newTextBoxDiv.after().html(newinput);

--- a/www/americangut/js/american_gut.js
+++ b/www/americangut/js/american_gut.js
@@ -144,7 +144,7 @@ function addDestinationFields(div_name,field1_name,field2_name) {
 		newinput+= '<option value="'+num+'">'+name+'</option>'
 	}
 	newinput+= '</select>'
-	newinput+= '<input type="text" value="Duration" name="'+field2_name+'_'+new_field_number+'" id="'+field2_name+'_'+new_field_number+'" class="smaller_text" onkeypress="validateNumber(event)"/> days <a class="remove_field" href="javascript:removeField(\''+div_name+'_'+new_field_number+'\')" title="Remove this field">x</a></input></div>'
+	newinput+= '<input type="text" value="Duration" name="'+field2_name+'_'+new_field_number+'" id="'+field2_name+'_'+new_field_number+'" class="smaller_text" onkeypress=\'validateNumber(event)\'/> days <a class="remove_field" href="javascript:removeField(\''+div_name+'_'+new_field_number+'\')" title="Remove this field">x</a></input></div>'
 	var newTextBoxDiv = $(document.createElement('div'))
 	     .attr("id", div_name+'_'+new_field_number);
 	newTextBoxDiv.after().html(newinput);

--- a/www/americangut/js/american_gut.js
+++ b/www/americangut/js/american_gut.js
@@ -144,7 +144,7 @@ function addDestinationFields(div_name,field1_name,field2_name) {
 		newinput+= '<option value="'+num+'">'+name+'</option>'
 	}
 	newinput+= '</select>'
-	newinput+= '<input type="text" value="Duration" name="'+field2_name+'_'+new_field_number+'" id="'+field2_name+'_'+new_field_number+'" class="smaller_text" onkeypress=\'validateNumber(event)\'/> days <a class="remove_field" href="javascript:removeField(\''+div_name+'_'+new_field_number+'\')" title="Remove this field">x</a></input></div>'
+	newinput+= '<input type="text" value="Duration" name="'+field2_name+'_'+new_field_number+'" id="'+field2_name+'_'+new_field_number+'" class="smaller_text" onkeypress=\'validateNumber(event, false)\'/> days <a class="remove_field" href="javascript:removeField(\''+div_name+'_'+new_field_number+'\')" title="Remove this field">x</a></input></div>'
 	var newTextBoxDiv = $(document.createElement('div'))
 	     .attr("id", div_name+'_'+new_field_number);
 	newTextBoxDiv.after().html(newinput);
@@ -355,7 +355,7 @@ function addHuman() {
 	field_name = "human"
 	var new_field_number = old_field_number+1
 	old_field_number = new_field_number
-	var newinput = '<div id="'+field_name+'_'+new_field_number+'"><input type="text" class="small_text" value="Age" name="'+field_name+'_'+new_field_number+'_age" id="'+field_name+'_'+new_field_number+'_age" onkeypress="validateNumber(event)"> years <br /><select name="'+field_name+'_'+new_field_number+'_sex" id="'+field_name+'_'+new_field_number+'_sex"><option value="">Select an option</option><option>Male</option><option>Female</option><option>Other</option></select><a class="remove_field" href="javascript:removeField(\''+field_name+'_'+new_field_number+'\')" title="Remove this pet">x</a></input></div>'
+	var newinput = '<div id="'+field_name+'_'+new_field_number+'"><input type="text" class="small_text" value="Age" name="'+field_name+'_'+new_field_number+'_age" id="'+field_name+'_'+new_field_number+'_age" onkeypress="validateNumber(event, false)"> years <br /><select name="'+field_name+'_'+new_field_number+'_sex" id="'+field_name+'_'+new_field_number+'_sex"><option value="">Select an option</option><option>Male</option><option>Female</option><option>Other</option></select><a class="remove_field" href="javascript:removeField(\''+field_name+'_'+new_field_number+'\')" title="Remove this pet">x</a></input></div>'
 	var newTextBoxDiv = $(document.createElement('div'))
 	     .attr("id", field_name+'_'+new_field_number);
 	newTextBoxDiv.after().html(newinput);
@@ -835,7 +835,7 @@ function validateText(evt) {
 }
 
 /* input field number validation*/
-function validateNumber(evt) {
+function validateNumber(evt, integer) {
   var theEvent = evt || window.event;
   if (theEvent.which == 0) {
     // this is a "special key," and theEvent.keyCode is not the ASCII value
@@ -854,6 +854,7 @@ function validateNumber(evt) {
     key = String.fromCharCode( key );
     // make sure the character typed is a number or a period
     var regex = /[0-9]|\./;
+    if (integer) regex = /[0-9]/;
     if( !regex.test(key) ) {
       theEvent.returnValue = false;
       if(theEvent.preventDefault) theEvent.preventDefault();

--- a/www/americangut/js/american_gut.js
+++ b/www/americangut/js/american_gut.js
@@ -837,15 +837,32 @@ function validateText(evt) {
 /* input field number validation*/
 function validateNumber(evt) {
   var theEvent = evt || window.event;
-  var key = theEvent.keyCode || theEvent.which;
-  //say what these keys are
-  if(theEvent.keyCode == 8 || theEvent.keyCode == 37|| theEvent.keyCode ==38|| theEvent.keyCode == 39|| theEvent.keyCode == 40 || theEvent.keyCode == 46 || theEvent.keyCode == 9)
-  	return
-  key = String.fromCharCode( key );
-  var regex = /[0-9]|\./;
-  if( !regex.test(key) ) {
-    theEvent.returnValue = false;
-    if(theEvent.preventDefault) theEvent.preventDefault();
+  if (theEvent.which == 0) {
+    console.log('which was 0');
+    console.log(theEvent.keyCode);
+    // this is a "special key," and theEvent.keyCode is not the ASCII value
+    // allow arrow keys (37-40), backspace (8), tab (9), and delete (46)
+    if(theEvent.keyCode == 8 || theEvent.keyCode == 37|| theEvent.keyCode ==38|| theEvent.keyCode == 39|| theEvent.keyCode == 40 || theEvent.keyCode == 46 || theEvent.keyCode == 9)
+      theEvent.returnValue = true;
+  }
+  else {
+    // this is a normal key, and theEvent.keyCode is the ASCII value
+    var key = theEvent.keyCode || theEvent.which;
+    // some browsers treat backspace as a normal key, so allow that
+    if (key == 8) {
+      theEvent.returnValue = true;
+      return;
+    }
+    console.log(key);
+    key = String.fromCharCode( key );
+    console.log(key);
+    console.log('*******');
+    // make sure the character typed is a number or a period
+    var regex = /[0-9]|\./;
+    if( !regex.test(key) ) {
+      theEvent.returnValue = false;
+      if(theEvent.preventDefault) theEvent.preventDefault();
+    }
   }
 }
 

--- a/www/americangut/js/american_gut.js
+++ b/www/americangut/js/american_gut.js
@@ -838,8 +838,6 @@ function validateText(evt) {
 function validateNumber(evt) {
   var theEvent = evt || window.event;
   if (theEvent.which == 0) {
-    console.log('which was 0');
-    console.log(theEvent.keyCode);
     // this is a "special key," and theEvent.keyCode is not the ASCII value
     // allow arrow keys (37-40), backspace (8), tab (9), and delete (46)
     if(theEvent.keyCode == 8 || theEvent.keyCode == 37|| theEvent.keyCode ==38|| theEvent.keyCode == 39|| theEvent.keyCode == 40 || theEvent.keyCode == 46 || theEvent.keyCode == 9)
@@ -853,10 +851,7 @@ function validateNumber(evt) {
       theEvent.returnValue = true;
       return;
     }
-    console.log(key);
     key = String.fromCharCode( key );
-    console.log(key);
-    console.log('*******');
     // make sure the character typed is a number or a period
     var regex = /[0-9]|\./;
     if( !regex.test(key) ) {

--- a/www/americangut/survey1.psp
+++ b/www/americangut/survey1.psp
@@ -78,10 +78,10 @@ other_selected = 'selected="selected"' if gender == 'Other' else ''
                                 <table>
                                     <tr>
                                         <td>
-                                        <input tabindex="4" class="small_text" type="text" name="height_in" id="height_in" onkeypress='validateNumber(event)' onblur="inToCm()" value=<%=quot(form, 'height_in_default')%> /> in
+                                        <input tabindex="4" class="small_text" type="text" name="height_in" id="height_in" onkeypress='validateNumber(event, true)' onblur="inToCm()" value=<%=quot(form, 'height_in_default')%> /> in
                                         </td>
                                         <td>
-                                        <input tabindex="4" class="small_text" type="text" name="height_cm" id="height_cm" onkeypress='validateNumber(event)' onblur="cmToIn()" value=<%=quot(form, 'height_cm_default')%> /> cm
+                                        <input tabindex="4" class="small_text" type="text" name="height_cm" id="height_cm" onkeypress='validateNumber(event, true)' onblur="cmToIn()" value=<%=quot(form, 'height_cm_default')%> /> cm
                                         </td>
                                     </tr>
                                 </table>
@@ -93,10 +93,10 @@ other_selected = 'selected="selected"' if gender == 'Other' else ''
                                 <table>
                                     <tr>
                                         <td>
-                                        <input tabindex="5" class="small_text" type="text" name="weight_lbs" id="weight_lbs" onkeypress='validateNumber(event)' onblur="lbsToKg()" value=<%=quot(form, 'weight_lbs_default')%> /> lbs
+                                        <input tabindex="5" class="small_text" type="text" name="weight_lbs" id="weight_lbs" onkeypress='validateNumber(event, true)' onblur="lbsToKg()" value=<%=quot(form, 'weight_lbs_default')%> /> lbs
                                         </td>
                                         <td>
-                                        <input tabindex="5" class="small_text" type="text" name="weight_kg" id="weight_kg" onkeypress='validateNumber(event)' onblur="kgToLbs()" value=<%=quot(form, 'weight_kg_default')%> /> kg
+                                        <input tabindex="5" class="small_text" type="text" name="weight_kg" id="weight_kg" onkeypress='validateNumber(event, true)' onblur="kgToLbs()" value=<%=quot(form, 'weight_kg_default')%> /> kg
                                         </td>
                                     </tr>
                                 </table>
@@ -104,7 +104,7 @@ other_selected = 'selected="selected"' if gender == 'Other' else ''
                         </tr>
                         <tr>
                             <td>Phone number</td>
-                            <td><input tabindex="6" type="text" name="phone_num" id="phone_num" onkeypress='validateNumber(event)' value=<%=quot(form, 'phone_num_default')%> /></td>
+                            <td><input tabindex="6" type="text" name="phone_num" id="phone_num" onkeypress='validateNumber(event, true)' value=<%=quot(form, 'phone_num_default')%> /></td>
                         </tr>
                         <tr>
                             <td>Current ZIP code</td>

--- a/www/americangut/survey3.psp
+++ b/www/americangut/survey3.psp
@@ -167,7 +167,7 @@ for c in d:
 # End for
 %>
                                                 </select>
-                                                <input type="text" name="travel_duration_1" id="travel_duration_1" value="Duration" class="smaller_text" onkeypress='validateNumber(event)'/> days
+                                                <input type="text" name="travel_duration_1" id="travel_duration_1" value="Duration" class="smaller_text" onkeypress='validateNumber(event, False)'/> days
                                             </div>
                                         </div>
                                         <a class="add_field" href="javascript:addDestinationFields(\'travel_options\',\'travel_location\',\'travel_duration\')" title="Add another destination">+</a>

--- a/www/americangut/survey3.psp
+++ b/www/americangut/survey3.psp
@@ -167,7 +167,7 @@ for c in d:
 # End for
 %>
                                                 </select>
-                                                <input type="text" name="travel_duration_1" id="travel_duration_1" value="Duration" class="smaller_text" onkeypress='validateNumber(event, False)'/> days
+                                                <input type="text" name="travel_duration_1" id="travel_duration_1" value="Duration" class="smaller_text" onkeypress='validateNumber(event, false)'/> days
                                             </div>
                                         </div>
                                         <a class="add_field" href="javascript:addDestinationFields(\'travel_options\',\'travel_location\',\'travel_duration\')" title="Add another destination">+</a>

--- a/www/americangut/survey3.psp
+++ b/www/americangut/survey3.psp
@@ -167,7 +167,7 @@ for c in d:
 # End for
 %>
                                                 </select>
-                                                <input type="text" name="travel_duration_1" id="travel_duration_1" value="Duration" class="smaller_text"/> days
+                                                <input type="text" name="travel_duration_1" id="travel_duration_1" value="Duration" class="smaller_text" onkeypress='validateNumber(event)'/> days
                                             </div>
                                         </div>
                                         <a class="add_field" href="javascript:addDestinationFields(\'travel_options\',\'travel_location\',\'travel_duration\')" title="Add another destination">+</a>


### PR DESCRIPTION
Noticed that validateNumber JS was misbehaving by allowing some characters (ampersand, percent sign, single quote, open-parenthesis) when it shouldn't.  This seems to work better on Chrome and Firefox; did not test IE.
