### PR TITLE
Fix formatting of vvalues to str

### DIFF
--- a/python_code/live_ebi_sra_rest_services.py
+++ b/python_code/live_ebi_sra_rest_services.py
@@ -297,7 +297,7 @@ class LiveEBISRARestServices(BaseRestServices):
                 
             study_file.write('            <STUDY_ATTRIBUTE>\n')
             study_file.write('                <TAG>{0}</TAG>\n'.format(item))
-            attribute_value = self.clean_whitespace(study_info[item])
+            attribute_value = self.clean_whitespace(str(study_info[item]))
             attribute_value = self.clean_text_value(attribute_value)
             study_file.write('                <VALUE>{0}</VALUE>\n'.format(attribute_value))
             study_file.write('            </STUDY_ATTRIBUTE>\n')


### PR DESCRIPTION
previously it was throwing errors if the value was not already a string, so it must be case with str()
