### PR TITLE
fix#540  This passes the study_id in the form

### DIFF
--- a/www/new_study.psp
+++ b/www/new_study.psp
@@ -22,7 +22,6 @@ form if the fields are valid.
 */
 
 <%
-
 if form['mode'] == 'new':
     req.write('$.validator.setDefaults({ ')
     req.write('submitHandler:function(){ ')
@@ -104,10 +103,11 @@ function check_study_name()
 # Find out if it's new or an edit
 page_mode = form['mode']
 portal_type = sess['portal_type']
-
+study_id = ''
 if page_mode == 'edit':
-    environmental_packages = qda.getStudyPackages(sess['study_id'])
-    study_info = qda.getStudyInfo(sess['study_id'], sess['web_app_user_id'])
+    study_id = form['study_id']
+    environmental_packages = qda.getStudyPackages(study_id)
+    study_info = qda.getStudyInfo(study_id, sess['web_app_user_id'])
     includes_timeseries = study_info['includes_timeseries']
     project_name = study_info['project_name']
     study_title = study_info['study_title']
@@ -332,6 +332,12 @@ else:
         </tr>
         
 <%
+if page_mode == 'edit':
+    #Indent
+%>
+    <input type ="hidden" name="study_id" id="study_id" value="<%=study_id%>">
+<%
+    #END Indent
 if sess['portal_type'] == 'emp':
     # Indent
     

--- a/www/new_study_submit.psp
+++ b/www/new_study_submit.psp
@@ -24,8 +24,9 @@ sess = Session.Session(req)
 
 portal_type = sess['portal_type']
 page_mode = form['page_mode']
+
 if page_mode == 'edit':
-    study_id = sess['study_id']
+    study_id = form['study_id']
 
 study_name = form['study_name']
 sess['study_name'] = study_name

--- a/www/select_study_task.psp
+++ b/www/select_study_task.psp
@@ -49,6 +49,7 @@ approved_qiime_submitters = [12428,12169,12171,12768,12782,12979,13019,12888]
             <form id="edit_study" action="fusebox.psp" method="post">
                 <input type="hidden" name="page" id="page" value="new_study.psp">
                 <input type="hidden" name="mode" id="mode" value="edit">
+                <input type="hidden" name="study_id" id="study_id" value=<%= '"'+str(study_id)+'"' %>>
                 <a href="" onclick="document.forms['edit_study'].submit(); return false;">
                 Edit study information</a>
             </form>


### PR DESCRIPTION
```
when editing a study, instead of collecting it from the
session. The study_id remains in the session so everything else
functions the same.  It is just added to the form and used from
the form when editing an existing study.
I tested by selecting a study "emily_test" study_id 2114
clicked on edit study
opened a second tab and logged in
selected study "emily_test_2" study_id 2134
went back to the first tab and edited the study.
Then I checked the database and the correct study was edited.
```
