### PR TITLE
Fix JavaScript exceptions raised in the survey

### DIFF
--- a/www/americangut/js/american_gut.js
+++ b/www/americangut/js/american_gut.js
@@ -381,6 +381,10 @@ function removeField(item_id) {
 }
 
 function otherSelect(select_id,item_id,other_index) {
+	if (document.getElementById(select_id) === null){
+		return;
+	}
+
 	if(document.getElementById(select_id).selectedIndex == other_index)
 	{
 		setVisible(item_id)

--- a/www/americangut/optional_questions.psp
+++ b/www/americangut/optional_questions.psp
@@ -96,11 +96,11 @@ if form.get('migraine', None) == 'yes':
                   $(this).focus();
                   }
               });
-        if (optional_questions.pregnant_yes.checked)
+        if (optional_questions.pregnant_yes !== undefined && optional_questions.pregnant_yes.checked)
             setVisible('pregnant_option');
-        if (optional_questions.diabetes_medication_yes.checked)
+        if (optional_questions.diabetes_medication_yes !== undefined && optional_questions.diabetes_medication_yes.checked)
             setVisible('diabetes_option');
-        if (optional_questions.migrainemeds_yes.checked)
+        if (optional_questions.migrainemeds_yes !== undefined && optional_questions.migrainemeds_yes.checked)
             setVisible('migraine_option');
         setDiabetesMedsDefaults('optional_questions', 'diabetes_medications', 'diabetes_medications_default[]');
         setMigraineMedsDefaults('optional_questions', 'migraine_medication', 'migraine_medication_default[]');
@@ -110,15 +110,6 @@ if form.get('migraine', None) == 'yes':
         $( "#progressbar" ).progressbar({
           value: 70
         });
-//        var button_clicked = false;
-//        $("#submit7").click(function() {
-//            button_clicked = true;
-//        });
-//        
-//        $(window).bind('beforeunload', function(){
-//            if(!button_clicked)
-//                return "If you navigate away from this page now, you will lose your progress on the survey, and the participant will not be added."
-//        });
       });
     </script>
     <br />


### PR DESCRIPTION
The exceptions were raised because some attributes are not defined
depending on which questions were answered; there are explicit changes
in place now to avoid this problem.

---

So commit.
