### PR TITLE
Remove debugging req.write from edit barcode

### DIFF
--- a/www/wwwadmin/ag_edit_barcode.psp
+++ b/www/wwwadmin/ag_edit_barcode.psp
@@ -65,7 +65,6 @@ if 'barcode' in form:
 	details = ag_data_access.getAGBarcodeDetails(barcode)
 
 	barcode_ag_kit_id = details['ag_kit_id']
-	req.write(barcode_ag_kit_id)
 	sample_date = '' if details['sample_date'] is None else \
         details['sample_date']
 	sample_time = '' if details['sample_time'] is None else \


### PR DESCRIPTION
There was a leftover req.write on the ag_edit_barcode.py page. This removes that line.
