### PR TITLE
Fix map markers on qiime and emp

### DIFF
--- a/www/visualize_all_sample_locations.psp
+++ b/www/visualize_all_sample_locations.psp
@@ -78,7 +78,7 @@ else:
     # Indent
 %>
         var pinColor = loc[4];
-        var pinImage = new google.maps.MarkerImage("http://chart.apis.google.com/chart?chst=d_map_pin_icon&chld=wc-male|" + pinColor,
+        var pinImage = new google.maps.MarkerImage("http://chart.apis.google.com/chart?chst=d_map_pin_letter&chld= |" + pinColor,
             new google.maps.Size(21, 34),
             new google.maps.Point(0,0),
             new google.maps.Point(10, 34));
@@ -90,6 +90,8 @@ else:
         var marker = new google.maps.Marker({
             position: myLatLng,
             map: map,
+            color: pinColor,
+            clickable: false,
             icon: pinImage,
             shadow: pinShadow
         });

--- a/www/visualize_all_sample_locations.psp
+++ b/www/visualize_all_sample_locations.psp
@@ -54,17 +54,19 @@ req.write('center: new google.maps.LatLng({0},{1}),'.format(center_lat, center_l
     setMarkers(map, latlongs_db);
 }
 
-function setMarkers(map, locations) 
+
+
+function setMarkers(map, locations)
 {
-    for (var i = 0; i < locations.length; i++) 
+    for (var i = 0; i < locations.length; i++)
     {
         var loc = locations[i];
         var myLatLng = new google.maps.LatLng(loc[1], loc[2]);
-        
+
 <%
 if tiny_markers:
     # Indent
-%>        
+%>
         var marker = new google.maps.Marker({
           position:myLatLng,
           map: map,
@@ -77,22 +79,34 @@ if tiny_markers:
 else:
     # Indent
 %>
-        var styleMaker1 = new StyledMarker({
-            styleIcon:new StyledIcon(StyledIconTypes.MARKER,{
-                size:(100,100),
-                color:loc[4]}),
-            position:myLatLng,
-            map:map,
-            title:loc[0]});
+        var pinColor = loc[4];
+        var pinImage = new google.maps.MarkerImage("http://chart.apis.google.com/chart?chst=d_map_pin_icon&chld=wc-male|" + pinColor,
+            new google.maps.Size(21, 34),
+            new google.maps.Point(0,0),
+            new google.maps.Point(10, 34));
+        var pinShadow = new google.maps.MarkerImage("http://chart.apis.google.com/chart?chst=d_map_pin_shadow",
+            new google.maps.Size(40, 37),
+            new google.maps.Point(0, 0),
+            new google.maps.Point(12, 35));
+
+        var marker = new google.maps.Marker({
+            position: myLatLng,
+            map: map,
+            icon: pinImage,
+            shadow: pinShadow
+        });
+
 <%
 # End if
 %>
 
-        
+
     }
 }
-
 </script>
+
+
+
 
 <%
 from data_access_connections import data_access_factory

--- a/www/visualize_all_sample_locations.psp
+++ b/www/visualize_all_sample_locations.psp
@@ -54,8 +54,6 @@ req.write('center: new google.maps.LatLng({0},{1}),'.format(center_lat, center_l
     setMarkers(map, latlongs_db);
 }
 
-
-
 function setMarkers(map, locations)
 {
     for (var i = 0; i < locations.length; i++)
@@ -100,13 +98,9 @@ else:
 # End if
 %>
 
-
     }
 }
 </script>
-
-
-
 
 <%
 from data_access_connections import data_access_factory

--- a/www/visualize_all_sample_locations.psp
+++ b/www/visualize_all_sample_locations.psp
@@ -98,6 +98,7 @@ else:
 # End if
 %>
 
+
     }
 }
 </script>


### PR DESCRIPTION
The map markers stopped working about a day ago but still worked on american gut.

I replaced the setMarkers function with the version of the function from the americangut page. 

Markers are displaying in firefox, Safari, and Chrome now. 
