### PR TITLE
change sender on emails

### DIFF
--- a/python_code/utils/mail.py
+++ b/python_code/utils/mail.py
@@ -5,7 +5,7 @@ from __future__ import division
 __author__ = "Yoshiki Vazquez-Baeza"
 __copyright__ = "Copyright 2009-2013, QIIME Web Analysis"
 __credits__ = ["Meg Pirrung", "Adam Robbins-Pianka", "Yoshiki Vazquez-Baeza",
-    "Daniel McDonald"]
+    "Daniel McDonald", "Emily TerAvest"]
 __license__ = "GPL"
 __version__ = "1.0.0.dev"
 __maintainer__ = ["Yoshiki Vazquez-Baeza"]
@@ -29,7 +29,7 @@ def can_send_mail():
     """
     return 'microbio.me' in gethostname()
 
-def send_email(message, subject, recipient='americangut@gmail.com'):
+def send_email(message, subject, recipient='americangut@gmail.com', sender=FROM_EMAIL):
     """Send an email from your local host """
 
     # Create a text/plain message
@@ -38,11 +38,11 @@ def send_email(message, subject, recipient='americangut@gmail.com'):
     # me == the sender's email address
     # you == the recipient's email address
     msg['Subject'] = subject
-    msg['From'] = FROM_EMAIL
+    msg['From'] = sender
     msg['To'] = recipient
 
     # Send the message via our own SMTP server, but don't include the
     # envelope header.
     s = smtplib.SMTP('localhost')
-    s.sendmail(FROM_EMAIL, [recipient], msg.as_string())
+    s.sendmail(sender, [recipient], msg.as_string())
     s.quit()

--- a/python_code/utils/mail.py
+++ b/python_code/utils/mail.py
@@ -29,7 +29,8 @@ def can_send_mail():
     """
     return 'microbio.me' in gethostname()
 
-def send_email(message, subject, recipient='americangut@gmail.com', sender=FROM_EMAIL):
+def send_email(message, subject, recipient='americangut@gmail.com',
+               sender=FROM_EMAIL):
     """Send an email from your local host """
 
     # Create a text/plain message

--- a/www/americangut/help_request.psp
+++ b/www/americangut/help_request.psp
@@ -2,7 +2,7 @@
 __author__ = "Meg Pirrung"
 __copyright__ = "Copyright 2009-2013, QIIME Web Analysis"
 __credits__ = ["Meg Pirrung", "Adam Robbins-Pianka", "Yoshiki Vazquez-Baeza",
-    "Daniel McDonald"]
+    "Daniel McDonald", "Emily TerAvest"]
 __license__ = "GPL"
 __version__ = "1.0.0.dev"
 __maintainer__ = ["Meg Pirrung"]
@@ -34,7 +34,7 @@ if email_address:
 
     try:
         if can_send_mail():
-            send_email(MESSAGE, SUBJECT)
+            send_email(MESSAGE, SUBJECT,sender=form_dict['email_address'])
         else:
             req.write(format_submit_form_to_fusebox_string(page="portal.psp",
                 message='Mail can only be sent from microbio.me domain.'))


### PR DESCRIPTION
Emails sent to the help account using the contact us form will now have the senders email in the reply to instead of the help account email. 
