### PR TITLE
Search AG_Handout_kits for kit_id and barcode

### DIFF
--- a/www/wwwadmin/ag_search.psp
+++ b/www/wwwadmin/ag_search.psp
@@ -268,16 +268,18 @@ if 'search_term' in form:
 				# Close the div for this login
 				req.write('</div>')
 				
-	elif len(handout_kit_list) > 0:
+	if len(handout_kit_list) > 0:
 		########################################
 		# Hand-out Kit information             #
 		########################################
+		req.write('<h2>Handout Kit Information Below</h2>')
 		for kit_id in handout_kit_list:
 			sql = """
 			select kit_id, password, barcode, verification_code 
 			from ag_handout_kits
 			where kit_id = '{0}'""".format(kit_id)
 			results = ag_data_access.dynamicMetadataSelect(sql).fetchall()
+			req.write('<div class="result_container">')
 			if len(results) > 0:
 				req.write('<table class="widetable">')
 				req.write('<th>kit_id</th>')
@@ -291,6 +293,7 @@ if 'search_term' in form:
 					req.write('<td>{}</td>'.format(tableout))
 					req.write('</tr>')
 				req.write('</table>')
+			req.write('</div>')
 
 	else:
 		message = 'No results found.'

--- a/www/wwwadmin/ag_search.psp
+++ b/www/wwwadmin/ag_search.psp
@@ -285,10 +285,11 @@ if 'search_term' in form:
 				req.write('<th>barcode</th>')
 				req.write('<th>verification_code</th>')
 				for row in results:
-						tableout= '</td><td>'.join(row)
-						req.write('<tr class="gridrow">')
-						req.write('<td>{}</td>'.format(tableout))
-						req.write('</tr>')
+					#the first <td> and last </td>  are added in the write
+					tableout= '</td><td>'.join(row)
+					req.write('<tr class="gridrow">')
+					req.write('<td>{}</td>'.format(tableout))
+					req.write('</tr>')
 				req.write('</table>')
 
 	else:

--- a/www/wwwadmin/ag_search.psp
+++ b/www/wwwadmin/ag_search.psp
@@ -1,5 +1,6 @@
 <%
 login_list = []
+kit_list =[]
 %>
 
 <style>
@@ -79,7 +80,14 @@ if 'search_term' in form:
 	for item in results:
 		if item[0] not in login_list:
 			login_list.append(item[0])
-	
+
+	#check matches in ag_handout_kits
+	sql = """
+	select kit_id from ag_handout_kits where kit_id like '%{0}%' or barcode like '%{0}%'""".format(search_term)
+	results = ag_data_access.dynamicMetadataSelect(sql).fetchall()
+	for item in results:
+		if item[0] not in kit_list:
+			kit_list.append(item[0])
 	# Output the results
 	if len(login_list) > 0:
 		message = ''
@@ -260,6 +268,28 @@ if 'search_term' in form:
 				# Close the div for this login
 				req.write('</div>')
 				
+	elif len(kit_list) > 0:
+		########################################
+		# Hand-out Kit information             #
+		########################################
+		for kit_id in kit_list:
+			sql = """
+			select kit_id, password, barcode, verification_code 
+			from ag_handout_kits
+			where kit_id = '{0}'""".format(kit_id)
+			results = ag_data_access.dynamicMetadataSelect(sql).fetchall()
+			if len(results) > 0:
+				req.write('<table class="widetable">')
+				req.write('<th>kit_id</th>')
+				req.write('<th>password</th>')
+				req.write('<th>barcode</th>')
+				req.write('<th>verification_code</th>')
+				for row in results:
+						tableout= '</td><td>'.join(row)
+						req.write('<tr class="gridrow">')
+						req.write('<td>{}</td>'.format(tableout))
+						req.write('</tr>')
+				req.write('</table>')
 
 	else:
 		message = 'No results found.'

--- a/www/wwwadmin/ag_search.psp
+++ b/www/wwwadmin/ag_search.psp
@@ -1,6 +1,6 @@
 <%
 login_list = []
-kit_list =[]
+handout_kit_list =[]
 %>
 
 <style>
@@ -86,8 +86,8 @@ if 'search_term' in form:
 	select kit_id from ag_handout_kits where kit_id like '%{0}%' or barcode like '%{0}%'""".format(search_term)
 	results = ag_data_access.dynamicMetadataSelect(sql).fetchall()
 	for item in results:
-		if item[0] not in kit_list:
-			kit_list.append(item[0])
+		if item[0] not in handout_kit_list:
+			handout_kit_list.append(item[0])
 	# Output the results
 	if len(login_list) > 0:
 		message = ''
@@ -268,11 +268,11 @@ if 'search_term' in form:
 				# Close the div for this login
 				req.write('</div>')
 				
-	elif len(kit_list) > 0:
+	elif len(handout_kit_list) > 0:
 		########################################
 		# Hand-out Kit information             #
 		########################################
-		for kit_id in kit_list:
+		for kit_id in handout_kit_list:
 			sql = """
 			select kit_id, password, barcode, verification_code 
 			from ag_handout_kits


### PR DESCRIPTION
Now that we are doing handout kits if a participant losses credentials sql is currently the only way to retrieve them. This change addes ag_handout_kits to the search page.  
If a kit_id or barcode is not found in the normal tables than ag_handout_kits is searched. 

barcodes to test with 
000000001 - normal results
000015537 - ag_handout_kit results with one barcode in the kit
000015522 - ag_handout_kit with 5 barcodes in the kit
010000000 - no results found

fixes #641 
