### PR TITLE
add account details and fix login redirect on emp

### DIFF
--- a/www/change_password.psp
+++ b/www/change_password.psp
@@ -159,6 +159,7 @@ if form.has_key('update_acct') and form.has_key('new_act_code'):
             <tr><td>Re-Type Password:</td><td><input type="password" id="new_password_again" name="new_password_again" /></td></tr>
             <tr><td colspan="2"><input type="submit" value="Change Password"></tr>
             </table>
+            <input type="hidden" name='portal_type' id='portal_type' value="<%=portal_type%>"/>
         </form>
 <%
     else:
@@ -192,6 +193,7 @@ elif form.has_key('update_username') and form.has_key('new_act_code'):
                 <tr><td>Re-Type Password:</td><td><input type="password" id="new_password_again" name="new_password_again" /></td></tr>
                 <tr><td colspan="2"><input type="submit" value="Change Password" /></tr>
                 </table>
+                <input type="hidden" name='portal_type' id='portal_type' value="<%=portal_type%>"/>
             </form>
 <%
     else:
@@ -211,7 +213,10 @@ elif form.has_key('username'):
         if good_password:
             updated_data = data_access.updateWebAppUserPwd( form["username"], form["new_password"] )
             req.write('<p>Your password has been updated!</p>')
-            req.write('<input type="button" onclick="send_me_home.submit();" value="Log In" \>')
+            if portal_type == 'emp':
+                req.write('<form action="/emp/index.psp"><button type="submit">Log In</button></form>')
+            else:
+                req.write('<input type="button" onclick="send_me_home.submit();" value="Log In" \>')
         else:
             #req.write('<div style="color:red;"><p><b>New Password Invalid!</b> Your password must contain at least 2 of following and have a length greater than 6 characters:</p><ul><li>non-alphanumeric characters </li><li> upper-case alphanumeric characters </li><li> lower-case alphanumeric characters </li><li> numbers </li></ul><p>For Example: "Password","password1" or "password*"</p></div>')
             req.write('<div style="color:red;"><p><b>New Password Invalid! Your password must be 6 or more characters.</b></p></div>')
@@ -224,7 +229,7 @@ elif form.has_key('username'):
                 <tr><td>Re-Type Password:</td><td><input type="password" id="new_password_again" name="new_password_again" /></td></tr>
                 <tr><td colspan="2"><input type="submit" value="Change Password" /></tr>
                 </table>
-                <type='portal_type' id='portal_type' value=<%portal_type%>/>
+                <input type="hidden" name='portal_type' id='portal_type' value="<%=portal_type%>"/>
             </form>
 <%
         #
@@ -240,7 +245,7 @@ elif form.has_key('username'):
             <tr><td>Re-Type Password:</td><td><input type="password" id="new_password_again" name="new_password_again" /></td></tr>
             <tr><td colspan="2"><input type="submit" value="Change Password" /></tr>
             </table>
-            <type='portal_type' id='portal_type' value=<%portal_type%>/>
+            <input type="hidden" name='portal_type' id='portal_type' value="<%=portal_type%>"/>
         </form>
 <%
     #
@@ -256,7 +261,7 @@ else:
         <tr><td>Re-Type Password:</td><td><input type="password" id="new_password_again" name="new_password_again" /></td></tr>
         <tr><td colspan="2"><input type="submit" value="Change Password" /></tr>
         </table>
-        <type='portal_type' id='portal_type' value=<%portal_type%>/>
+        <input type="hidden" name='portal_type' id='portal_type' value="<%=portal_type%>"/>
     </form>
 <%
 #

--- a/www/change_password.psp
+++ b/www/change_password.psp
@@ -20,8 +20,11 @@ import gc
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <%
+portal_type = 'qiime'
 if 'portal_type' in form:
-    req.write('<title>EMP</title>')
+    portal_type = form['portal_type']
+if portal_type == 'emp':
+    req.write('<title>Earth Microbiome Project</title>')
 else:
     req.write('<title>Qiime</title>')
 #END INDENT
@@ -29,7 +32,7 @@ else:
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
 <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon" />
 <%
-if 'portal_type' in form:
+if portal_type == 'emp':
     req.write('<link rel="stylesheet" href="style/emp.css" type="text/css">')
 else:
     req.write('<link rel="stylesheet" href="style/qiime.css" type="text/css">')
@@ -221,6 +224,7 @@ elif form.has_key('username'):
                 <tr><td>Re-Type Password:</td><td><input type="password" id="new_password_again" name="new_password_again" /></td></tr>
                 <tr><td colspan="2"><input type="submit" value="Change Password" /></tr>
                 </table>
+                <type='portal_type' id='portal_type' value=<%portal_type%>/>
             </form>
 <%
         #
@@ -236,6 +240,7 @@ elif form.has_key('username'):
             <tr><td>Re-Type Password:</td><td><input type="password" id="new_password_again" name="new_password_again" /></td></tr>
             <tr><td colspan="2"><input type="submit" value="Change Password" /></tr>
             </table>
+            <type='portal_type' id='portal_type' value=<%portal_type%>/>
         </form>
 <%
     #
@@ -251,6 +256,7 @@ else:
         <tr><td>Re-Type Password:</td><td><input type="password" id="new_password_again" name="new_password_again" /></td></tr>
         <tr><td colspan="2"><input type="submit" value="Change Password" /></tr>
         </table>
+        <type='portal_type' id='portal_type' value=<%portal_type%>/>
     </form>
 <%
 #

--- a/www/change_password.psp
+++ b/www/change_password.psp
@@ -19,10 +19,22 @@ import gc
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<title>Qiime</title>
+<%
+if 'portal_type' in form:
+    req.write('<title>EMP</title>')
+else:
+    req.write('<title>Qiime</title>')
+#END INDENT
+%>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
 <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon" />
-<link rel="stylesheet" href="style/qiime.css" type="text/css">
+<%
+if 'portal_type' in form:
+    req.write('<link rel="stylesheet" href="style/emp.css" type="text/css">')
+else:
+    req.write('<link rel="stylesheet" href="style/qiime.css" type="text/css">')
+#END INDENT
+%>
 <script type="text/javascript" src="./js/qiime.js"></script>
 <script type="text/javascript" src="./js/jquery_validate/lib/jquery.js"></script>
 <script type="text/javascript" src="./js/jquery_validate/lib/jquery.metadata.js"></script>

--- a/www/emp/index.psp
+++ b/www/emp/index.psp
@@ -19,6 +19,7 @@ locale.setlocale(locale.LC_ALL, 'en_US')
 data_access = data_access_factory(ServerConfig.data_access_type)
 sess = Session.Session(req)
 sess['portal_type'] = 'emp'
+sess['stylesheet'] = 'style/emp.css'
 sess.save()
 
 # Get the general statistics
@@ -136,7 +137,6 @@ plots['country'] = 'By Location'
 <title>Earth Microbiome Project - Metadata Portal</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
 
-<link rel="stylesheet" href="/qiime/style/style.css" type="text/css">
 <link rel="stylesheet" href="/qiime/style/emp.css" type="text/css">
 <link class="include" rel="stylesheet" type="text/css" href="/qiime/js/jqChartJQueryPlugin_3_0_0_0/css/jquery.jqChart.css" />
 

--- a/www/emp/index.psp
+++ b/www/emp/index.psp
@@ -200,7 +200,7 @@ if form.has_key('username'):
         sess.set_timeout(604800)
         sess.save()
 
-        req.write('''<form action="http://www.microbio.me/qiime/index.psp" method="post" name="login_form" id="login_form">
+        req.write('''<form action="/qiime/index.psp" method="post" name="login_form" id="login_form">
         <input type="hidden" name="page" value="./select_study.psp">
         <input type="hidden" name="portal_type" value="emp">
         <input type="hidden" name="username" value="%s">
@@ -242,6 +242,14 @@ if form.has_key('username'):
 
 <br/>
 
+<table>
+    <tr>
+        <td><a href="/qiime/register_user.psp?portal_type=emp">Create Account</a></td>
+        <td> | </td>
+        <td><a href="/qiime/forgot_password.psp?portal_type=emp">Reset Password</a></td>
+        <td> | </td>
+        <td><a href="/qiime/change_password.psp?portal_type=emp">Change Password</a></td>
+</table>
 
 
 

--- a/www/forgot_password.psp
+++ b/www/forgot_password.psp
@@ -22,10 +22,22 @@ from send_mail_from_server import process_and_send_email
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<title>Qiime</title>
+<%
+if 'portal_type' in form:
+    req.write('<title>EMP</title>')
+else:
+    req.write('<title>Qiime</title>')
+#END INDENT
+%>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
 <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon" />
-<link rel="stylesheet" href="style/qiime.css" type="text/css">
+<%
+if 'portal_type' in form:
+    req.write('<link rel="stylesheet" href="style/emp.css" type="text/css">')
+else:
+    req.write('<link rel="stylesheet" href="style/qiime.css" type="text/css">')
+#END INDENT
+%>
 <script type="text/javascript" src="./js/qiime.js"></script>
 <script type="text/javascript" src="./js/jquery_validate/lib/jquery.js"></script>
 <script type="text/javascript" src="./js/jquery_validate/lib/jquery.metadata.js"></script>

--- a/www/forgot_password.psp
+++ b/www/forgot_password.psp
@@ -23,8 +23,11 @@ from send_mail_from_server import process_and_send_email
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <%
+portal_type = 'qiime'
 if 'portal_type' in form:
-    req.write('<title>EMP</title>')
+    portal_type = form['portal_type']
+if portal_type == 'emp':
+    req.write('<title>Earth Microbiome Project</title>')
 else:
     req.write('<title>Qiime</title>')
 #END INDENT
@@ -32,7 +35,7 @@ else:
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
 <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon" />
 <%
-if 'portal_type' in form:
+if portal_type == 'emp':
     req.write('<link rel="stylesheet" href="style/emp.css" type="text/css">')
 else:
     req.write('<link rel="stylesheet" href="style/qiime.css" type="text/css">')
@@ -157,6 +160,7 @@ if form.has_key('username'):
             <tr><td>Username (email):</td><td><input type="text" id="username" name="username" /></td></tr>
             <tr><td colspan="2"><input type="submit" value="Send E-mail" /></tr>
             </table>
+            <name='portal_type' id='portal_type' value=<%portal_type%>/>
         </form>
 <%
     # display default page if this is not a form submission load
@@ -167,6 +171,7 @@ else:
     <tr><td>Username (email):</td><td><input type="text" id="username" name="username" /></td></tr>
     <tr><td colspan="2"><input type="submit" value="Send E-mail" /></tr>
     </table>
+    <name='portal_type' id='portal_type' value=<%portal_type%>/>
 </form>
 <%
 #

--- a/www/forgot_password.psp
+++ b/www/forgot_password.psp
@@ -150,7 +150,10 @@ if form.has_key('username'):
             'QIIME account', \
             'Acct: %s\n\nPlease click on the link below to change your QIIME password:\n\nhttp://microbio.me/qiime/change_password.psp?update_acct=%s;new_act_code=%s' % (form['username'],form['username'],new_act_code))
         req.write('<p>You will receive an email shortly regarding your account.</p>')
-        req.write('<input type="button" onclick="send_me_home.submit();" value="Log In" \>')
+        if portal_type == 'emp':
+            req.write('<form action="/emp/index.psp"><button type="submit">Log In</button></form>')
+        else:
+            req.write('<input type="button" onclick="send_me_home.submit();" value="Log In" \>')
     else:
         # if username is invalid let the user know
         req.write('<p style="color:red;">This username does not exist!</p>')
@@ -160,7 +163,7 @@ if form.has_key('username'):
             <tr><td>Username (email):</td><td><input type="text" id="username" name="username" /></td></tr>
             <tr><td colspan="2"><input type="submit" value="Send E-mail" /></tr>
             </table>
-            <name='portal_type' id='portal_type' value=<%portal_type%>/>
+            <input type='hidden' name='portal_type' id='portal_type' value="<%=portal_type%>"/>
         </form>
 <%
     # display default page if this is not a form submission load
@@ -171,7 +174,7 @@ else:
     <tr><td>Username (email):</td><td><input type="text" id="username" name="username" /></td></tr>
     <tr><td colspan="2"><input type="submit" value="Send E-mail" /></tr>
     </table>
-    <name='portal_type' id='portal_type' value=<%portal_type%>/>
+    <input type='hidden' name='portal_type' id='portal_type' value="<%=portal_type%>"/>
 </form>
 <%
 #

--- a/www/index.psp
+++ b/www/index.psp
@@ -295,11 +295,11 @@ else:
 
 <table>
     <tr>
-        <td><a href="./register_user.psp">Create Account</a></td>
+        <td><a href="./register_user.psp?portal_type='qiime'">Create Account</a></td>
         <td> | </td>
-        <td><a href="./forgot_password.psp">Reset Password</a></td>
+        <td><a href="./forgot_password.psp?portal_type='qiime'">Reset Password</a></td>
         <td> | </td>
-        <td><a href="./change_password.psp">Change Password</a></td>
+        <td><a href="./change_password.psp?portal_tpye='qiime'">Change Password</a></td>
 </table>
 
 <br/>

--- a/www/register_user.psp
+++ b/www/register_user.psp
@@ -23,10 +23,22 @@ from send_mail_from_server import process_and_send_email
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<title>Qiime</title>
+<%
+if 'portal_type' in form:
+    req.write('<title>EMP</title>')
+else:
+    req.write('<title>Qiime</title>')
+#END INDENT
+%>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
 <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon" />
-<link rel="stylesheet" href="style/qiime.css" type="text/css">
+<%
+if 'portal_type' in form:
+    req.write('<link rel="stylesheet" href="style/emp.css" type="text/css">')
+else:
+    req.write('<link rel="stylesheet" href="style/qiime.css" type="text/css">')
+#END INDENT
+%>
 <script type="text/javascript" src="./js/qiime.js"></script>
 <script type="text/javascript" src="./js/jquery_validate/lib/jquery.js"></script>
 <script type="text/javascript" src="./js/jquery_validate/lib/jquery.metadata.js"></script>

--- a/www/register_user.psp
+++ b/www/register_user.psp
@@ -24,8 +24,11 @@ from send_mail_from_server import process_and_send_email
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <%
+portal_type = 'qiime'
 if 'portal_type' in form:
-    req.write('<title>EMP</title>')
+    portal_type = form['portal_type']
+if portal_type == 'emp':
+    req.write('<title>Earth Mircrobiome Project</title>')
 else:
     req.write('<title>Qiime</title>')
 #END INDENT
@@ -33,7 +36,7 @@ else:
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
 <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon" />
 <%
-if 'portal_type' in form:
+if portal_type == 'emp':
     req.write('<link rel="stylesheet" href="style/emp.css" type="text/css">')
 else:
     req.write('<link rel="stylesheet" href="style/qiime.css" type="text/css">')
@@ -178,6 +181,7 @@ if form.has_key('username'):
             <tr><td>Re-Type Password:</td><td><input type="password" id="password_again" name="password_again" /></td></tr>
             <tr><td colspan="2"><input type="submit" value="Create User" /></tr>
             </table>
+            <type='portal_type' id='portal_type' value=<%portal_type%>/>
         </form>
 <%
     elif available and not good_password:
@@ -193,6 +197,7 @@ if form.has_key('username'):
             <tr><td>Re-Type Password:</td><td><input type="password" id="password_again" name="password_again" /></td></tr>
             <tr><td colspan="2"><input type="submit" value="Create User" /></tr>
             </table>
+            <type='portal_type' id='portal_type' value=<%portal_type%>/>
         </form>
 <%
     else:
@@ -206,6 +211,7 @@ if form.has_key('username'):
             <tr><td>Re-Type Password:</td><td><input type="password" id="password_again" name="password_again" /></td></tr>
             <tr><td colspan="2"><input type="submit" value="Create User" /></tr>
             </table>
+            <type='portal_type' id='portal_type' value=<%portal_type%>/>
         </form>
 <%
 else:
@@ -218,6 +224,7 @@ else:
         <tr><td>Re-Type Password:</td><td><input type="password" id="password_again" name="password_again" /></td></tr>
         <tr><td colspan="2"><input type="submit" value="Create User" /></tr>
         </table>
+        <type='portal_type' id='portal_type' value=<%portal_type%>/>
     </form>
 <%
 #

--- a/www/register_user.psp
+++ b/www/register_user.psp
@@ -181,7 +181,7 @@ if form.has_key('username'):
             <tr><td>Re-Type Password:</td><td><input type="password" id="password_again" name="password_again" /></td></tr>
             <tr><td colspan="2"><input type="submit" value="Create User" /></tr>
             </table>
-            <type='portal_type' id='portal_type' value=<%portal_type%>/>
+            <input type='hidden' name='portal_type' id='portal_type' value="<%=portal_type%>"/>
         </form>
 <%
     elif available and not good_password:
@@ -197,7 +197,7 @@ if form.has_key('username'):
             <tr><td>Re-Type Password:</td><td><input type="password" id="password_again" name="password_again" /></td></tr>
             <tr><td colspan="2"><input type="submit" value="Create User" /></tr>
             </table>
-            <type='portal_type' id='portal_type' value=<%portal_type%>/>
+              <input type='hidden' name='portal_type' id='portal_type' value="<%=portal_type%>"/>
         </form>
 <%
     else:
@@ -211,7 +211,7 @@ if form.has_key('username'):
             <tr><td>Re-Type Password:</td><td><input type="password" id="password_again" name="password_again" /></td></tr>
             <tr><td colspan="2"><input type="submit" value="Create User" /></tr>
             </table>
-            <type='portal_type' id='portal_type' value=<%portal_type%>/>
+              <input type='hidden' name='portal_type' id='portal_type' value="<%=portal_type%>"/>
         </form>
 <%
 else:
@@ -224,7 +224,7 @@ else:
         <tr><td>Re-Type Password:</td><td><input type="password" id="password_again" name="password_again" /></td></tr>
         <tr><td colspan="2"><input type="submit" value="Create User" /></tr>
         </table>
-        <type='portal_type' id='portal_type' value=<%portal_type%>/>
+          <input type='hidden' name='portal_type' id='portal_type' value="<%=portal_type%>"/>
     </form>
 <%
 #


### PR DESCRIPTION
fixes#655
fixes#623 

This changes the emp login page to redirect to the system you are not production. 
This also adds the 'create account', 'forgot password' and 'change password' links to the emp login page. 

This also changes those 3 pages to be stylized based on emp or qiime. 

It needs to be tested on webdev because of the email issues... 
