### PR TITLE
Split on ';' rather than '; ' when parsing

### DIFF
--- a/www/americangut/taxa_summary.psp
+++ b/www/americangut/taxa_summary.psp
@@ -41,7 +41,7 @@ else:
     headers = '\t'.join(headers)
 
     # read lines from taxa summary table, omit comment lines
-    lines = [x.replace('; ', '\t').strip() for x in
+    lines = [x.replace(';', '\t').strip() for x in
         open(taxa_summary_fp, 'U').readlines() if not x.startswith('#')]
 
     # remove the greengenes prefixes


### PR DESCRIPTION
This is required for taxa summaries to display correctly _regardless_ of whether or not the hierarchy is delimited with semicolon or semicolon-space.  Needs merge and deploy ASAP in order for latest results to be viewable by participants.
