### PR TITLE
Display 'no results found' correctly on ag_search

### DIFF
--- a/www/wwwadmin/ag_search.psp
+++ b/www/wwwadmin/ag_search.psp
@@ -295,7 +295,7 @@ if 'search_term' in form:
 				req.write('</table>')
 			req.write('</div>')
 
-	else:
+	if len(handout_kit_list) == 0 and len(login_list) == 0:
 		message = 'No results found.'
 		req.write(message)
 


### PR DESCRIPTION
When we added the tmp_handout_kits search to ag_search and we changed the if, elif, else logic to always display results form tmp_handout_kits we didn't change the else statement, so it turned into if, if, else.  I changed the final else to be if len(handout_kits_list) == 0 and len(login_list) == 0:
Now "No Results Found" will be displayed only when their are no results found. 

Barcodes to test with 
00020000 : No results 
000015801:  handout results only 
000001081: normal results only 
