### PR TITLE
Add kit id and kit email to email about child participant

### DIFF
--- a/www/americangut/new_participant.psp
+++ b/www/americangut/new_participant.psp
@@ -120,7 +120,7 @@ Key Personnel:
             <tr><td>Name of participant</td><td><input tabindex="2" type="text" name="participant_name" id="participant_name" onkeypress='validateText(event)'><div class="red right">*</div></td></tr>
             <tr><td>Email of participant</td><td><input tabindex="3" type="text" name="participant_email" id="participant_email"  onkeypress='validateEmail(event)'><div class="red right">*</div></td></tr>
             <tr><td>Participant is 13 years of age or younger</td><td><input type="checkbox" tabindex="4" name="is_juvenile" id="is_juvenile" class="is_juvenile" onclick="toggleConsent()"></td></tr>
-            <tr><td></td><td><input type="radio" tabindex="5" name="juvenile_age" id="juvenile_age_less_than_7" value="under 7">&nbsp;&nbsp;Participant is older than 3 months and younger than 13 years of age</td></tr>
+            <tr><td></td><td><input type="radio" tabindex="5" name="juvenile_age" id="juvenile_age_less_than_7" value="under 7">&nbsp;&nbsp;Participant is older than 3 months and younger than 7 years of age</td></tr>
             <tr><td></td><td><input type="radio" tabindex="6" name="juvenile_age" id="juvenile_age_more_than_7" value="between 7 and 13">&nbsp;&nbsp;Participant is between 7 and 13 years of age</td></tr>
             <tr><td>Name of parent/guardian 1</td><td><input tabindex="7" type="text" name="parent_1_name" id="parent_1_name" onkeypress='validateText(event)'></td></tr>
             <tr><td>Name of parent/guardian 2</td><td><input tabindex="8" type="text" name="parent_2_name" id="parent_2_name" onkeypress='validateText(event)'></td></tr>

--- a/www/americangut/survey_main.psp
+++ b/www/americangut/survey_main.psp
@@ -43,9 +43,11 @@ if form.get('is_juvenile', 'off') == 'on':
         Parent/Guardian 1: %s
         Parent/Guardian 2: %s
         Deceased: %s
+        Kit id: %s
         --------------------------------------------------------------------------------
         """ % (form['participant_name'], form['juvenile_age'],
-               form['parent_1_name'], form['parent_2_name'], form.get('deceased_parent', 'off'))
+               form['parent_1_name'], form['parent_2_name'], form.get('deceased_parent', 'off'),
+               sess['supplied_kit_id'])
 
         try:
             if can_send_mail():

--- a/www/americangut/survey_main.psp
+++ b/www/americangut/survey_main.psp
@@ -4,7 +4,7 @@ from utils.mail import send_email, can_send_mail
 
 deceased_parent_checkbox_checked = form.get('deceased_parent', None)
 ag_login_id = sess['user_data']['web_app_user_id']
-
+kit_email = sess['user_data']['email']
 # check if the participant already exists
 participants = ag_data_access.getHumanParticipants(ag_login_id)
 
@@ -44,10 +44,11 @@ if form.get('is_juvenile', 'off') == 'on':
         Parent/Guardian 2: %s
         Deceased: %s
         Kit id: %s
+        Email: %s
         --------------------------------------------------------------------------------
         """ % (form['participant_name'], form['juvenile_age'],
                form['parent_1_name'], form['parent_2_name'], form.get('deceased_parent', 'off'),
-               sess['supplied_kit_id'])
+               sess['supplied_kit_id'], kit_email)
 
         try:
             if can_send_mail():


### PR DESCRIPTION
3 things changed here. 

The bullet point for "juvenile_age_less_than_7" now reads "Participant is older than 3 months and younger than 7 years of age" instead of "Participant is older than 3 months and younger than 13 years of age"

two new pieces of information are added to the email that gets sent to the help account. 
kit_id and
kit email address

Previously only the ag_login_id was provided and I would have to look up the kit id for Elaine based on the ag_login_id
