### PR TITLE
Add thailand; add code to correct some ZIPs

### DIFF
--- a/database/procedures/ag_get_barcode_metadata.sql
+++ b/database/procedures/ag_get_barcode_metadata.sql
@@ -150,7 +150,7 @@ select akb.barcode as sample_name,
         end as state,
         case 
             when zip is null then 'unknown'
-            when regexp_like(zip, '^\d*$') then lpad(zip, 5, 0)
+            when regexp_like(zip, '^\d*$') and len(zip) < 5 then lpad(zip, 5, '0')
             else zip
         end as zip,
         case 

--- a/database/procedures/ag_get_barcode_metadata.sql
+++ b/database/procedures/ag_get_barcode_metadata.sql
@@ -150,6 +150,7 @@ select akb.barcode as sample_name,
         end as state,
         case 
             when zip is null then 'unknown'
+            when regexp_like(zip, '^\d*$') then lpad(zip, 5, 0)
             else zip
         end as zip,
         case 
@@ -187,6 +188,7 @@ select akb.barcode as sample_name,
             when lower(country) = 'scotland' then 'GAZ:Scotland'
             when lower(country) = 'united arab emirates' then 'GAZ:United Arab Emirates'
             when lower(country) = 'ireland' then 'GAZ:Ireland'
+            when lower(country) = 'thailand' then 'GAZ:Thailand'
             else 'unknown'
         end as country,
         case


### PR DESCRIPTION
Gail noticed these problems in the most recent metadata, so adding code to correct the issues.  While working on this, found out about [Oracle's `regexp_like` function](http://docs.oracle.com/cd/B12037_01/server.101/b10759/conditions018.htm), which is neat and could come in handy in a lot of places!
