### PR TITLE
Only pull down Month and Year

### DIFF
--- a/database/procedures/ag_get_barcode_metadata.sql
+++ b/database/procedures/ag_get_barcode_metadata.sql
@@ -317,7 +317,7 @@ select akb.barcode as sample_name,
         end as ASTHMA, 
         case 
             when BIRTH_DATE is null then 'unknown'
-            else REPLACE(REPLACE(REPLACE(BIRTH_DATE, CHR(10)), CHR(13)), CHR(9))
+            else REGEXP_REPLACE(REPLACE(REPLACE(REPLACE(BIRTH_DATE, CHR(10)), CHR(13)), CHR(9)), '([[:digit:]]{2})/([[:digit:]]{2})/([[:digit:]]{4})', '\1/\3')
         end as BIRTH_DATE, 
         case 
             when CAT is null then 'unknown'
@@ -1033,6 +1033,6 @@ end;
 
 /*
 variable results_cursor REFCURSOR;
-exec ag_check_barcode_metadata('000001002', :results_cursor);
+exec ag_get_barcode_metadata('000001002', :results_cursor);
 print results_cursor;
 */


### PR DESCRIPTION
We should change the web interface as well, but in the meantime this will suffice to pull down only the month and year of the birthdate provided by participants.  EBI still needs to be updated.
